### PR TITLE
added validation for "title" and "color" fields

### DIFF
--- a/src/main/java/com/todolist/models/Task.java
+++ b/src/main/java/com/todolist/models/Task.java
@@ -61,4 +61,10 @@ public class Task implements Auditable {
                 " color: " + color;
     }
 
+    public String getColorAsName() {
+        if(color != null) {
+            return color.name();
+        }
+        return "UNDEFINED";
+    }
 }

--- a/src/main/java/com/todolist/models/TaskDto.java
+++ b/src/main/java/com/todolist/models/TaskDto.java
@@ -1,20 +1,24 @@
 package com.todolist.models;
 
+import jakarta.validation.constraints.NotEmpty;
+
 public class TaskDto {
 
     private Long id;
+    @NotEmpty()
     private String title;
     private String description;
-    private Color color;
+    @NotEmpty()
+    private String color;
 
-    public TaskDto(Long id, String title, String description, Color color) {
+    public TaskDto(Long id, String title, String description, String color) {
         this.id = id;
         this.title = title;
         this.description = description;
         this.color = color;
     }
 
-    public Color getColor() {
+    public String getColor() {
         return color;
     }
 

--- a/src/main/java/com/todolist/services/TaskService.java
+++ b/src/main/java/com/todolist/services/TaskService.java
@@ -20,9 +20,9 @@ public class TaskService {
     }
 
     public TaskDto saveTask(TaskDto taskDto) {
-        Task taskToSave = new Task(taskDto.getTitle(), taskDto.getDescription(), taskDto.getColor());
+        Task taskToSave = new Task(taskDto.getTitle(), taskDto.getDescription(), Color.valueOf(taskDto.getColor()));
         Task task = taskRepository.saveTask(taskToSave);
-        return new TaskDto(task.getId(), task.getTitle(), task.getDescription(), task.getColor());
+        return new TaskDto(task.getId(), task.getTitle(), task.getDescription(), task.getColorAsName());
     }
 
     public List<Task> getTasks(Color color, String title) {


### PR DESCRIPTION
Stworzyłem swojego PR bo doszedłeś do ściany, więc tak będzie szybciej.

Kilka spraw:
1. poszperałem trochę i to pozwalanie wyświetlania się błędów przez Springa (to co wpisywałeś w application.properties), jest podobono złą praktyką bo nie kontrolujesz co z twojej apki wycieka. I np. error moze miec jakies wrażliwe dane a jakiś rysiek dostanie te info w odpowiediz bo z automatu wszystkie errory mu sie wyswietlą.
2. Walidacja enuma. To jest rzecz ktorej normalnie nie da sie przeskoczyc. Proces zawsze wyglada tak samo. Przychodzi request z obiektem w body (w formie jsona). Spring go deserializuje czyli zamienia z jsona w obiekt TaskDto. I dopiero potem przeprowadza walidacje na obiekcie. Problem jest tylko w przypadku jak enum jest pusty. Enum "Color" nie ma pustych wartości, ma "RED", "GREEN"... Więc wysypuje się deserializacja, bo jak jedno pole nie moze byc zdeserializowane to caly obiekt leży i kwiczy. 


Rozwiązanie: Wywalenie z TaskDTO enuma. dto ma kilka odpowiedzialnosci: deserializacja, serialziacja, walidacja, Jak przez uzycie enuma nie jestesmy w stanie przeprowadzic walidacji do konca to mozna sie go pozbyc. Enum zostaje w klasie Task, bo tam nie ma walidacji. 